### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  actions: read
+  statuses: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/0xApeToshi/pgbackupy/security/code-scanning/1](https://github.com/0xApeToshi/pgbackupy/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.
- `statuses: write` for updating commit statuses (if necessary for test reporting).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`test`) to limit permissions to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
